### PR TITLE
Support async

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ classifiers = [
 dependencies = [
   "openai>=0.27.0",
   "tqdm>=4.0",
-  "PyYAML>=6.0"
+  "PyYAML>=6.0",
+  "asgiref>=3.0"
 ]
 
 [tool.setuptools.packages.find]

--- a/src/sculptor/sculptor.py
+++ b/src/sculptor/sculptor.py
@@ -1,6 +1,6 @@
 import json
 from typing import Dict, Any, Optional, List, Type, Union
-from utils import load_config
+from .utils import load_config
 import openai
 from string import Template
 import inspect

--- a/src/sculptor/sculptor.py
+++ b/src/sculptor/sculptor.py
@@ -1,11 +1,12 @@
 import json
 from typing import Dict, Any, Optional, List, Type, Union
-from .utils import load_config
+from utils import load_config
 import openai
 from string import Template
 import inspect
 import copy
 import time
+from asgiref.sync import sync_to_async
 
 ALLOWED_TYPES = {
     "string": str,
@@ -391,3 +392,11 @@ class Sculptor:
                 results.append(sculpt_with_merge(item))
 
         return results
+    
+    async def sculpt_async(self, data: Dict[str, Any], merge_input: bool = True, retries: int = 3) -> Dict[str, Any]:
+        """Processes a single data item using the LLM asynchronously."""
+        return await sync_to_async(self.sculpt)(data, merge_input, retries)
+    
+    async def sculpt_batch_async(self, data_list: List[Dict[str, Any]], n_workers: int = 100, show_progress: bool = True, merge_input: bool = True, retries: int = 3) -> List[Dict[str, Any]]:
+        """Processes multiple data items using the LLM asynchronously."""
+        return await sync_to_async(self.sculpt_batch)(data_list, n_workers, show_progress, merge_input, retries)


### PR DESCRIPTION
<img width="819" alt="Screenshot 2025-02-10 at 1 56 44 PM" src="https://github.com/user-attachments/assets/83ada7f3-2f2b-4ac2-a054-c5549debd5c9" />

This I think is the simplest change that allows calling async versions of the sculpt / sculpt batch methods. n_workers can be set to the maximum supported/desired concurrent requests. 

I was experimenting with a larger change that supported passing in the AsyncOpenAI client and calling the async version of that request. After looking into it more I do not think that there is any performance improvement to doing that vs just setting the n_workers higher in the synchronous function's ThreadPoolExecutor, but just a semantic difference. So I don't think that is necessary for now at least. 

The above screenshot shows both the sync and async versions of the function processing ~65 items/second with 100 concurrent workers. So I think the main difference is just that this exposes async functions that can be called with await. 

https://github.com/django/asgiref/